### PR TITLE
Add firmware URL for R02 3.0.0.17_240903

### DIFF
--- a/OTA_firmwares/Firmware_URLs.txt
+++ b/OTA_firmwares/Firmware_URLs.txt
@@ -1,3 +1,4 @@
 http://api2.qcwxkjvip.com/download/ota/R01_V1.0/R01_1.00.01_231229.bin
 http://api2.qcwxkjvip.com/download/ota/R02_V1.0/R02_1.00.05_211220.bin
 http://api2.qcwxkjvip.com/download/ota/R02_V3.0/R02_3.00.06_240523.bin
+http://api2.qcwxkjvip.com/download/ota/R02_V3.0/R02_3.00.17_240903.bin


### PR DESCRIPTION
Add a firmware URL for 3.0.0.17_240903


As an aside:
I would have included another firmware URL in this PR but I am unsure of the hardware revisions, I believe it's due to a different Bluetooth IC. Related to: https://github.com/atc1441/ATC_RF03_Ring/issues/26#issue-2754402309
I have an R02, app displays as an R02, but the firmware URL fetched is:
`http://api2.qcwxkjvip.com/download/ota/RY02_V3.0/RY02_3.00.31_241207.bin` resulting in hardware version of RY02. The firmware header is also different:
<img width="1354" alt="Screenshot 2024-12-30 at 19 54 25" src="https://github.com/user-attachments/assets/7c5eadec-6fdf-4f14-8054-25c3b8e89871" /> This warrants further investigate and discussion.
